### PR TITLE
fixed tests path so fixtures can be loaded

### DIFF
--- a/src/bootstrap_phpunit.php
+++ b/src/bootstrap_phpunit.php
@@ -129,7 +129,7 @@ $ciunit_folder = dirname(__FILE__);
  *
  * This is the path to the tests folder.
  */
-$tests_folder = dirname(__FILE__) . "/../../../tests";
+$tests_folder = dirname(__FILE__) . "/../../../../tests";
 
 
 // --------------------------------------------------------------------


### PR DESCRIPTION
The path used to build the TESTSPATH constant is one parent directory too short. It is only used for loading fixtures, so the bug doesn't show up until you try to do so.