### PR TITLE
Fix wrong path on tests

### DIFF
--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -2,7 +2,7 @@
 
 <phpunit colors="true"
          stopOnFailure="false"
-         bootstrap="../vendor/Celc/ciunit/src/bootstrap_phpunit.php">
+         bootstrap="../vendor/celc/ciunit/src/bootstrap_phpunit.php">
     <php>
         <server name="SERVER_NAME" value="http://example.com"/>
     </php>


### PR DESCRIPTION
This would fix this error on linux:

Cannot open file "/home/nnieto/code/tests/../vendor/Celc/ciunit/src/bootstrap_phpunit.php".